### PR TITLE
Prepare registry for integration with Namadillo

### DIFF
--- a/_IBC/namadahousefire-cosmoshubtestnet.json
+++ b/_IBC/namadahousefire-cosmoshubtestnet.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "namadahousefire",
+    "client_id": "07-tendermint-6",
+    "connection_id": "connection-5"
+  },
+  "chain_2": {
+    "chain_name": "cosmoshubtestnet",
+    "client_id": "07-tendermint-3844",
+    "connection_id": "connection-3882"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-5",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-4398",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1"
+    }
+  ]
+}

--- a/_IBC/namadahousefire-osmosistestnet.json
+++ b/_IBC/namadahousefire-osmosistestnet.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "namadahousefire",
+    "client_id": "07-tendermint-5",
+    "connection_id": "connection-4"
+  },
+  "chain_2": {
+    "chain_name": "osmosistestnet",
+    "client_id": "07-tendermint-4142",
+    "connection_id": "connection-3599"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-4",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-9457",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1"
+    }
+  ]
+}

--- a/_IBC/namadainternaldevnet-cosmoshubtestnet.json
+++ b/_IBC/namadainternaldevnet-cosmoshubtestnet.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "namadainternaldevnet",
+    "client_id": "07-tendermint-0",
+    "connection_id": "connection-0"
+  },
+  "chain_2": {
+    "chain_name": "cosmoshubtestnet",
+    "client_id": "07-tendermint-3792",
+    "connection_id": "connection-3832"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-0",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-4353",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1"
+    }
+  ]
+}

--- a/namadahousefire/assetlist.json
+++ b/namadahousefire/assetlist.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "../assetlist.schema.json",
+  "chain_name": "namadahousefire",
+  "assets": [
+    {
+      "description": "The native token of Namada.",
+      "denom_units": [
+        {
+          "denom": "unam",
+          "exponent": 0
+        },
+        {
+          "denom": "nam",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "sdk.coin",
+      "base": "unam",
+      "name": "NAM",
+      "display": "nam",
+      "symbol": "NAM",
+      "address": "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/anoma/namada-chain-registry/main/namada/images/namada.svg"
+      }
+    }
+  ]
+}

--- a/namadahousefire/chain.json
+++ b/namadahousefire/chain.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../chain.schema.json",
-  "chain_name": "namada",
+  "chain_name": "namadahousefire",
   "status": "upcoming",
   "network_type": "testnet",
   "website": "https://namada.net",
   "pretty_name": "Namada",
   "chain_type": "namada",
-  "chain_id": "internal-devnet-44a.1bd3e6ca62",
+  "chain_id": "housefire-cotton.d3c912fee7462",
   "slip44": 118,
   "bech32_prefix": "tnam",
   "daemon_name": "unam",
@@ -38,15 +38,24 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://proxy.public.heliax.work/internal-devnet-44a.1bd3e6ca62",
-        "provider": "Heliax"
-      }
-    ],
-    "rest": [
+        "address": "https://rpc.knowable.run",
+        "provider": "Knowable"
+      },
       {
-        "address": "https://proxy.public.heliax.work/internal-devnet-44a.1bd3e6ca62",
-        "provider": "Heliax"
+        "address": "https://namada-rpc-housefire.mandragora.io",
+        "provider": "Mandragora"
       }
     ]
+  },
+  "explorers": [
+    {
+      "kind": "Shielded.Live",
+      "url": "https://shielded.live/",
+      "tx_page": "https://shielded.live/txs/${txHash}",
+      "account_page": "https://shielded.live/address/${accountAddress}"
+    }
+  ],
+  "logo_URIs": {
+    "svg": "https://raw.githubusercontent.com/anoma/namada-chain-registry/main/namada/images/namada.svg"
   }
 }

--- a/namadainternaldevnet/assetlist.json
+++ b/namadainternaldevnet/assetlist.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../assetlist.schema.json",
-  "chain_name": "namada",
+  "chain_name": "namadainternaldevnet",
   "assets": [
     {
       "description": "The native token of Namada.",
@@ -18,7 +18,11 @@
       "base": "unam",
       "name": "NAM",
       "display": "nam",
-      "symbol": "NAM"
+      "symbol": "NAM",
+      "address": "tnam1qy440ynh9fwrx8aewjvvmu38zxqgukgc259fzp6h",
+      "logo_URIs": {
+        "svg": "https://raw.githubusercontent.com/anoma/namada-chain-registry/main/namada/images/namada.svg"
+      }
     }
   ]
 }

--- a/namadainternaldevnet/chain.json
+++ b/namadainternaldevnet/chain.json
@@ -1,12 +1,12 @@
 {
   "$schema": "../chain.schema.json",
-  "chain_name": "namada",
+  "chain_name": "namadainternaldevnet",
   "status": "upcoming",
   "network_type": "testnet",
   "website": "https://namada.net",
   "pretty_name": "Namada",
   "chain_type": "namada",
-  "chain_id": "housefire-cotton.d3c912fee7462",
+  "chain_id": "internal-devnet-44a.1bd3e6ca62",
   "slip44": 118,
   "bech32_prefix": "tnam",
   "daemon_name": "unam",
@@ -38,21 +38,18 @@
   "apis": {
     "rpc": [
       {
-        "address": "https://rpc.knowable.run",
-        "provider": "Knowable"
-      },
+        "address": "https://proxy.public.heliax.work/internal-devnet-44a.1bd3e6ca62",
+        "provider": "Heliax"
+      }
+    ],
+    "rest": [
       {
-        "address": "https://namada-rpc-housefire.mandragora.io",
-        "provider": "Mandragora"
+        "address": "https://proxy.public.heliax.work/internal-devnet-44a.1bd3e6ca62",
+        "provider": "Heliax"
       }
     ]
   },
-  "explorers": [
-    {
-      "kind": "Shielded.Live",
-      "url": "https://shielded.live/",
-      "tx_page": "https://shielded.live/txs/${txHash}",
-      "account_page": "https://shielded.live/address/${accountAddress}"
-    }
-  ]
+  "logo_URIs": {
+    "svg": "https://raw.githubusercontent.com/anoma/namada-chain-registry/main/namada/images/namada.svg"
+  }
 }


### PR DESCRIPTION
### Changed
- Change file structure to match cosmos/chain-registry
- Give housefire and internal devnet chains distinct names
- Add tnam address for decoding NAM asset without requiring an indexer. See https://github.com/anoma/namada-interface/pull/1235#discussion_r1833454082

### Added
- Add IBC configs
- Add Namada icon for chains and NAM assets