### PR TITLE
fix: Update with current Housefire details

### DIFF
--- a/namadadryrun/chain.json
+++ b/namadadryrun/chain.json
@@ -11,7 +11,7 @@
   "bech32_prefix": "tnam",
   "daemon_name": "unam",
   "key_algos": ["ed25519"],
-  "features": [],
+  "features": ["claimRewards"],
   "fees": {
     "fee_tokens": [
       {

--- a/namadahousefire/chain.json
+++ b/namadahousefire/chain.json
@@ -6,7 +6,7 @@
   "website": "https://namada.net",
   "pretty_name": "Namada",
   "chain_type": "namada",
-  "chain_id": "housefire-cotton.d3c912fee7462",
+  "chain_id": "housefire-equal.130b1076e3250f",
   "slip44": 877,
   "bech32_prefix": "tnam",
   "daemon_name": "unam",


### PR DESCRIPTION
The Housefire testnet has been relaunched, giving us a new chain ID and native token address:

https://testnet.knowable.run/

- [x] Update Housefire ChainID
- [x] Add `claimRewards` feature flag to dryrun chain