### PR TITLE
DryRun - Enable Phase 3 features

### DIFF
--- a/namadadryrun/chain.json
+++ b/namadadryrun/chain.json
@@ -11,7 +11,7 @@
   "bech32_prefix": "tnam",
   "daemon_name": "unam",
   "key_algos": ["ed25519"],
-  "features": ["claimRewards"],
+  "features": ["claimRewards", "masp", "ibcTransfers", "ibcShielding"],
   "fees": {
     "fee_tokens": [
       {


### PR DESCRIPTION
Enable Phase 3 features on dryrun upon the passing of https://interface.namada-dryrun.tududes.com/governance/proposal/2

- `ibcTransfers`
- `ibcShielding`
- `masp`