### PR TITLE
Adding the namadadryrun & Osmosis mainnet channel configs

### DIFF
--- a/_IBC/namadadryrun-osmosis.json
+++ b/_IBC/namadadryrun-osmosis.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "namadadryrun",
+    "client_id": "07-tendermint-1",
+    "connection_id": "connection-1"
+  },
+  "chain_2": {
+    "chain_name": "osmosis",
+    "client_id": "07-tendermint-3352",
+    "connection_id": "connection-3885"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-1",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-86536",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1"
+    }
+  ]
+}

--- a/_IBC/osmosis-namadadryrun.json
+++ b/_IBC/osmosis-namadadryrun.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "../ibc_data.schema.json",
+  "chain_1": {
+    "chain_name": "osmosis",
+    "client_id": "07-tendermint-3352",
+    "connection_id": "connection-3885"
+  },
+  "chain_2": {
+    "chain_name": "namadadryrun",
+    "client_id": "07-tendermint-1",
+    "connection_id": "connection-1"
+  },
+  "channels": [
+    {
+      "chain_1": {
+        "channel_id": "channel-86536",
+        "port_id": "transfer"
+      },
+      "chain_2": {
+        "channel_id": "channel-1",
+        "port_id": "transfer"
+      },
+      "ordering": "unordered",
+      "version": "ics20-1"
+    }
+  ]
+}


### PR DESCRIPTION
For Phase 3, we are enabling IBC between Osmosis Mainnet and Namada Dry-Run.

This is the configuration I was provided:

```bash
export CHAIN_A_ID="namada-dryrun.abaaeaf7b78cb3ac"
export CHAIN_A_CHANNEL_ID="channel-1"
export CHAIN_A_KEY_NAME="relayer-namada"
export CHAIN_A_CLIENT_ID="07-tendermint-1"

export CHAIN_B_ID="osmosis-1" # Osmosis mainnet
export CHAIN_B_CHANNEL_ID="channel-86536"
export CHAIN_B_KEY_NAME="relayer-osmosis"
export CHAIN_B_CLIENT_ID="07-tendermint-3352"
```