### PR TITLE
Enable DryRun Shielding Rewards (phase 4)

### DIFF
--- a/namadadryrun/chain.json
+++ b/namadadryrun/chain.json
@@ -11,7 +11,13 @@
   "bech32_prefix": "tnam",
   "daemon_name": "unam",
   "key_algos": ["ed25519"],
-  "features": ["claimRewards", "masp", "ibcTransfers", "ibcShielding"],
+  "features": [
+    "claimRewards",
+    "masp",
+    "ibcTransfers",
+    "ibcShielding",
+    "shieldingRewards"
+  ],
   "fees": {
     "fee_tokens": [
       {


### PR DESCRIPTION
Enables phase 4 features in Namadillo for `namadadryrun`