### PR TITLE
Namada mainnet chain_name should be namada

### DIFF
--- a/namada/chain.json
+++ b/namada/chain.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../chain.schema.json",
-  "chain_name": "namadamainnet",
+  "chain_name": "namada",
   "status": "upcoming",
   "network_type": "mainnet",
   "website": "https://namada.net",


### PR DESCRIPTION
After moving mainnet config into `namada`, I forgot to update `chain_name`. Fixing here!