### PR TITLE
Add Phase 2 features to mainnet Namada!

### DIFF
--- a/namada/chain.json
+++ b/namada/chain.json
@@ -11,7 +11,7 @@
   "bech32_prefix": "tnam",
   "daemon_name": "unam",
   "key_algos": ["ed25519"],
-  "features": [],
+  "features": ["claimRewards"],
   "fees": {
     "fee_tokens": [
       {


### PR DESCRIPTION
See https://interface.namada.tududes.com/governance/proposal/1

This proposal will likely go live at Epoch 48, and this PR simply adds the `claimRewards` feature to the registry to enable it in all deployed Namadillos.

This should be merged when that proposal goes live! Dec 15, 2024, 10:14 (EDT)